### PR TITLE
YD Trim actuation indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ Use of this code in other freeware projects is permitted with acknowledgment.
 * v1.0 - Initial Release.
 * v1.1 - Changed settings to a menu UI
 * v1.2 - Added feedback in the menu UI for rudder trim position and movement
+* v1.2.1 - Corrected bug resulting in trim actuation display remaining when YD disengaged.

--- a/src/Scripts/xpYawDamper.lua
+++ b/src/Scripts/xpYawDamper.lua
@@ -11,6 +11,7 @@
 * v1.0 - Initial Release.
 * v1.1 - Changed settings to a menu UI.
 * v1.2 - Added feedback in the menu UI for rudder trim position and movement.
+* v1.2.1 - Corrected bug with trim actuation display remaining when disconnected.
 * 
 * Copyright (C) 2022  N1K340
 * 
@@ -152,9 +153,13 @@ function xpYawDampFuntion()
 	-- Status Text
 	if WEIGHT_ON_WHEELS == 1 then
 		status_txt = "YD Not Active on the ground"
+		status_m = ""
+		status_pl = ""
 	end
 	if WEIGHT_ON_WHEELS == 0 and YD_STATUS == 0 then
 		status_txt = "YD is currently OFF"
+		status_m = ""
+		status_pl = ""
 	end
 	if WEIGHT_ON_WHEELS == 0 and YD_STATUS == 1 then
 		status_txt = "YD is currently ACTIVE"


### PR DESCRIPTION
Added logic to clear the YD trim actuator indications when the YD is disconnected through system deselected or weight on wheels.

Closes #10 
Tested OK in XP12 C750